### PR TITLE
[fix] alphabet proxies were broken before

### DIFF
--- a/test/unit/alphabet/alphabet_proxy_test_template.hpp
+++ b/test/unit/alphabet/alphabet_proxy_test_template.hpp
@@ -1,0 +1,245 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2022 deCODE Genetics
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/biocpp/biocpp-core/blob/main/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <bio/alphabet/concept.hpp>
+#include <bio/alphabet/exception.hpp>
+#include <bio/meta/concept/core_language.hpp>
+
+template <typename T>
+struct proxy_fixture : ::testing::Test
+{
+    /* needs to be specialised for ever type that uses this test!
+     *
+     * Must provide as public members:
+     *
+     * T default_init;
+     * T t0;
+     * T t1;
+     *
+     */
+};
+
+constexpr size_t maximum_iterations_ = 65536u;
+
+TYPED_TEST_SUITE_P(proxy_fixture);
+
+TYPED_TEST_P(proxy_fixture, concept_check)
+{
+    EXPECT_TRUE(bio::alphabet::semialphabet<TypeParam>);
+    EXPECT_TRUE(bio::alphabet::semialphabet<TypeParam &>);
+    EXPECT_TRUE(bio::alphabet::semialphabet<TypeParam const>);
+    EXPECT_TRUE(bio::alphabet::semialphabet<TypeParam const &>);
+
+    EXPECT_TRUE(bio::alphabet::writable_semialphabet<TypeParam>);
+    EXPECT_TRUE(bio::alphabet::writable_semialphabet<TypeParam &>);
+    // proxies ARE const-assignable
+    EXPECT_TRUE(bio::alphabet::writable_semialphabet<TypeParam const>);
+    EXPECT_TRUE(bio::alphabet::writable_semialphabet<TypeParam const &>);
+
+    EXPECT_TRUE(bio::alphabet::alphabet<TypeParam>);
+    EXPECT_TRUE(bio::alphabet::alphabet<TypeParam &>);
+    EXPECT_TRUE(bio::alphabet::alphabet<TypeParam const>);
+    EXPECT_TRUE(bio::alphabet::alphabet<TypeParam const &>);
+
+    EXPECT_TRUE(bio::alphabet::writable_alphabet<TypeParam>);
+    EXPECT_TRUE(bio::alphabet::writable_alphabet<TypeParam &>);
+    // proxies ARE const-assignable
+    EXPECT_TRUE(bio::alphabet::writable_alphabet<TypeParam const>);
+    EXPECT_TRUE(bio::alphabet::writable_alphabet<TypeParam const &>);
+}
+
+TYPED_TEST_P(proxy_fixture, type_properties)
+{
+    // It is highly recommended that non-reference types that model this concept, also model:
+    EXPECT_TRUE((bio::meta::standard_layout<TypeParam>));
+    // not regular because not default-constructible
+    //     EXPECT_TRUE((std::regular<TypeParam>));
+    // usually not trivially copyable because of "assign-through"
+    //     EXPECT_TRUE((bio::meta::trivially_copyable<TypeParam>));
+}
+
+TYPED_TEST_P(proxy_fixture, alphabet_size)
+{
+    EXPECT_GT(bio::alphabet::alphabet_size<TypeParam>, 0u);
+}
+
+TYPED_TEST_P(proxy_fixture, assign_rank_to)
+{
+    EXPECT_EQ((bio::alphabet::assign_rank_to(0, this->t0)), this->default_init);
+
+    for (size_t i = 0u; i < bio::alphabet::alphabet_size<TypeParam> && i < maximum_iterations_; ++i)
+        bio::alphabet::assign_rank_to(i, this->t0);
+
+    EXPECT_TRUE((std::is_same_v<decltype(bio::alphabet::assign_rank_to(0, this->t0)), TypeParam &>));
+    EXPECT_TRUE((std::is_same_v<decltype(bio::alphabet::assign_rank_to(0, std::move(this->t0))), TypeParam>));
+}
+
+TYPED_TEST_P(proxy_fixture, to_rank)
+{
+    EXPECT_EQ(bio::alphabet::to_rank(this->default_init), 0u);
+
+    for (size_t i = 0; i < bio::alphabet::alphabet_size<TypeParam> && i < maximum_iterations_; ++i)
+        EXPECT_EQ((bio::alphabet::to_rank(bio::alphabet::assign_rank_to(i, this->t0))), i);
+
+    EXPECT_TRUE(
+      (std::is_same_v<decltype(bio::alphabet::to_rank(this->t0)), bio::alphabet::alphabet_rank_t<TypeParam>>));
+}
+
+TYPED_TEST_P(proxy_fixture, copy_constructor)
+{
+    // the module operation ensures that the result is within the valid rank range;
+    // it will be in the most cases 1 except for alphabets like bio::alphabet::gap where it will be 0
+    constexpr bio::alphabet::alphabet_rank_t<TypeParam> rank = 1 % bio::alphabet::alphabet_size<TypeParam>;
+    bio::alphabet::assign_rank_to(rank, this->t1);
+    TypeParam t2{this->t1};
+    TypeParam t3(this->t1);
+    EXPECT_EQ(this->t1, t2);
+    EXPECT_EQ(t2, t3);
+}
+
+TYPED_TEST_P(proxy_fixture, move_constructor)
+{
+    constexpr bio::alphabet::alphabet_rank_t<TypeParam> rank = 1 % bio::alphabet::alphabet_size<TypeParam>;
+    bio::alphabet::assign_rank_to(rank, this->t0);
+    bio::alphabet::assign_rank_to(rank, this->t1);
+
+    TypeParam t2{std::move(this->t1)};
+    EXPECT_EQ(t2, this->t0);
+    TypeParam t3(std::move(t2));
+    EXPECT_EQ(t3, this->t0);
+}
+
+TYPED_TEST_P(proxy_fixture, copy_assignment)
+{
+    constexpr bio::alphabet::alphabet_rank_t<TypeParam> rank = 1 % bio::alphabet::alphabet_size<TypeParam>;
+    bio::alphabet::assign_rank_to(rank, this->t1);
+    TypeParam t2{this->default_init};
+    EXPECT_NE(this->t1, t2);
+
+    t2 = this->t1;
+    EXPECT_EQ(this->t1, t2);
+}
+
+TYPED_TEST_P(proxy_fixture, move_assignment)
+{
+    constexpr bio::alphabet::alphabet_rank_t<TypeParam> rank = 1 % bio::alphabet::alphabet_size<TypeParam>;
+    bio::alphabet::assign_rank_to(rank, this->t1);
+    TypeParam t2{this->default_init};
+    EXPECT_NE(this->t1, t2);
+
+    t2 = this->t1;
+    EXPECT_EQ(this->t1, t2);
+}
+
+TYPED_TEST_P(proxy_fixture, swap_)
+{
+    constexpr bio::alphabet::alphabet_rank_t<TypeParam> rank = 1 % bio::alphabet::alphabet_size<TypeParam>;
+    bio::alphabet::assign_rank_to(rank, this->t1);
+    EXPECT_EQ(this->t0.to_rank(), 0ull);
+    EXPECT_EQ(this->t1.to_rank(), 1ull);
+
+    using std::swap;
+    swap(this->t0, this->t1);
+    EXPECT_EQ(this->t0.to_rank(), 1ull);
+    EXPECT_EQ(this->t1.to_rank(), 0ull);
+}
+
+TYPED_TEST_P(proxy_fixture, comparison_operators)
+{
+    bio::alphabet::assign_rank_to(0, this->t0);
+    bio::alphabet::assign_rank_to(1 % bio::alphabet::alphabet_size<TypeParam>, this->t1);
+
+    EXPECT_EQ(this->t0, this->t0);
+    EXPECT_LE(this->t0, this->t1);
+    EXPECT_LE(this->t1, this->t1);
+    EXPECT_EQ(this->t1, this->t1);
+    EXPECT_GE(this->t1, this->t1);
+    EXPECT_GE(this->t1, this->t0);
+
+    if constexpr (bio::alphabet::alphabet_size<TypeParam> == 1)
+    {
+        EXPECT_EQ(this->t0, this->t1);
+    }
+    else
+    {
+        EXPECT_LT(this->t0, this->t1);
+        EXPECT_NE(this->t0, this->t1);
+        EXPECT_GT(this->t1, this->t0);
+    }
+}
+
+TYPED_TEST_P(proxy_fixture, assign_char_to)
+{
+    using char_t = bio::alphabet::alphabet_char_t<TypeParam>;
+    if constexpr (std::integral<char_t>)
+    {
+        char_t i = std::numeric_limits<char_t>::min();
+        char_t j = std::numeric_limits<char_t>::max();
+
+        for (size_t k = 0; i < j && k < maximum_iterations_; ++i, ++k)
+            bio::alphabet::assign_char_to(i, this->t0);
+
+        EXPECT_TRUE((std::is_same_v<decltype(bio::alphabet::assign_char_to(0, this->t0)), TypeParam &>));
+        EXPECT_TRUE((std::is_same_v<decltype(bio::alphabet::assign_char_to(0, std::declval<TypeParam>())), TypeParam>));
+    }
+}
+
+TYPED_TEST_P(proxy_fixture, char_is_valid_for) // only test negative example for most; more inside specialised tests
+{
+    // includes most of our alphabets, but not the adaptations!
+    if constexpr (bio::alphabet::alphabet_size<TypeParam> < 255)
+    {
+        EXPECT_FALSE((bio::alphabet::char_is_valid_for<TypeParam>(0))); // for none of our alphabets char{0} is valid
+    }
+}
+
+TYPED_TEST_P(proxy_fixture, assign_char_strictly_to)
+{
+    using char_t = bio::alphabet::alphabet_char_t<TypeParam>;
+    if constexpr (std::integral<char_t>)
+    {
+        char_t i = std::numeric_limits<char_t>::min();
+        char_t j = std::numeric_limits<char_t>::max();
+
+        for (size_t k = 0; i < j && k < maximum_iterations_; ++i, ++k)
+        {
+            if (bio::alphabet::char_is_valid_for<TypeParam>(i))
+                EXPECT_NO_THROW(bio::alphabet::assign_char_strictly_to(i, this->t0));
+            else
+                EXPECT_THROW(bio::alphabet::assign_char_strictly_to(i, this->t0),
+                             bio::alphabet::invalid_char_assignment);
+        }
+    }
+}
+
+TYPED_TEST_P(proxy_fixture, to_char)
+{
+    EXPECT_TRUE(
+      (std::is_same_v<decltype(bio::alphabet::to_char(this->t0)), bio::alphabet::alphabet_char_t<TypeParam>>));
+
+    // more elaborate tests are done in specific alphabets
+}
+
+REGISTER_TYPED_TEST_SUITE_P(proxy_fixture,
+                            concept_check,
+                            type_properties,
+                            alphabet_size,
+                            assign_rank_to,
+                            to_rank,
+                            copy_constructor,
+                            move_constructor,
+                            copy_assignment,
+                            move_assignment,
+                            swap_,
+                            comparison_operators,
+                            assign_char_to,
+                            char_is_valid_for,
+                            assign_char_strictly_to,
+                            to_char);

--- a/test/unit/alphabet/detail/alphabet_proxy_test.cpp
+++ b/test/unit/alphabet/detail/alphabet_proxy_test.cpp
@@ -9,10 +9,7 @@
 #include <bio/alphabet/detail/alphabet_proxy.hpp>
 #include <bio/alphabet/nucleotide/dna4.hpp>
 
-#include "../alphabet_constexpr_test_template.hpp"
-#include "../alphabet_test_template.hpp"
-#include "../semi_alphabet_constexpr_test_template.hpp"
-#include "../semi_alphabet_test_template.hpp"
+#include "../alphabet_proxy_test_template.hpp"
 
 class alphabet_proxy_example : public bio::alphabet::alphabet_proxy<alphabet_proxy_example, bio::alphabet::dna4>
 {
@@ -21,25 +18,61 @@ private:
     using base_t        = bio::alphabet::alphabet_proxy<alphabet_proxy_example, alphabet_type>;
     friend base_t;
 
-    constexpr void on_update() noexcept {}
+    bio::alphabet::dna4 * ptr;
 
 public:
-    constexpr alphabet_proxy_example() noexcept                                  = default;
-    constexpr alphabet_proxy_example(alphabet_proxy_example const &)             = default;
-    constexpr alphabet_proxy_example(alphabet_proxy_example &&)                  = default;
-    constexpr alphabet_proxy_example & operator=(alphabet_proxy_example const &) = default;
-    constexpr alphabet_proxy_example & operator=(alphabet_proxy_example &&)      = default;
-    ~alphabet_proxy_example()                                                    = default;
+    constexpr alphabet_proxy_example() noexcept                      = delete;
+    constexpr alphabet_proxy_example(alphabet_proxy_example const &) = default;
+    constexpr alphabet_proxy_example(alphabet_proxy_example &&)      = default;
+    ~alphabet_proxy_example()                                        = default;
 
-    constexpr alphabet_proxy_example(alphabet_type const a) noexcept : base_t{a} {};
+    constexpr alphabet_proxy_example(bio::alphabet::dna4 & in) : ptr{&in} {}
 
     using base_t::operator=;
+
+    constexpr alphabet_proxy_example & operator=(alphabet_proxy_example const & rhs)
+    {
+        return assign_rank(rhs.to_rank());
+    }
+
+    constexpr alphabet_proxy_example const & operator=(alphabet_proxy_example const & rhs) const
+    {
+        return assign_rank(rhs.to_rank());
+    }
+
+    constexpr size_t to_rank() const noexcept
+    {
+        return ptr->to_rank(); // This would have actual implementation
+    }
+
+    constexpr alphabet_proxy_example & assign_rank(size_t const r) noexcept
+    {
+        ptr->assign_rank(r);
+        return *this;
+    }
+
+    constexpr alphabet_proxy_example const & assign_rank(size_t const r) const noexcept
+    {
+        ptr->assign_rank(r);
+        return *this;
+    }
 };
 
-INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy, alphabet, alphabet_proxy_example, );
-INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy, semi_alphabet_test, alphabet_proxy_example, );
-INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy, alphabet_constexpr, alphabet_proxy_example, );
-INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy, semi_alphabet_constexpr, alphabet_proxy_example, );
+using bio::alphabet::operator""_dna4;
+
+template <>
+struct proxy_fixture<alphabet_proxy_example> : public ::testing::Test
+{
+    bio::alphabet::dna4 def{};
+    bio::alphabet::dna4 a0 = 'A'_dna4;
+    bio::alphabet::dna4 a1 = 'C'_dna4;
+
+    alphabet_proxy_example default_init{def};
+    alphabet_proxy_example t0{a0};
+    alphabet_proxy_example t1{a1};
+};
+
+INSTANTIATE_TYPED_TEST_SUITE_P(proxy1_test, proxy_fixture, ::testing::Types<alphabet_proxy_example>, );
 
 // -----------------------------------------------------------------------------------------------------
 // check handling of external types that do not provide members
@@ -114,18 +147,51 @@ private:
     using base_t        = bio::alphabet::alphabet_proxy<alphabet_proxy_example2, alphabet_type>;
     friend base_t;
 
-    constexpr void on_update() noexcept {}
+    my_namespace::my_alph * ptr;
 
 public:
-    constexpr alphabet_proxy_example2() noexcept                                   = default;
-    constexpr alphabet_proxy_example2(alphabet_proxy_example2 const &)             = default;
-    constexpr alphabet_proxy_example2(alphabet_proxy_example2 &&)                  = default;
-    constexpr alphabet_proxy_example2 & operator=(alphabet_proxy_example2 const &) = default;
-    constexpr alphabet_proxy_example2 & operator=(alphabet_proxy_example2 &&)      = default;
-    ~alphabet_proxy_example2()                                                     = default;
+    constexpr alphabet_proxy_example2() noexcept                       = default;
+    constexpr alphabet_proxy_example2(alphabet_proxy_example2 const &) = default;
+    constexpr alphabet_proxy_example2(alphabet_proxy_example2 &&)      = default;
+    ~alphabet_proxy_example2()                                         = default;
 
-    constexpr alphabet_proxy_example2(alphabet_type const a) noexcept : base_t{a} {};
+    constexpr alphabet_proxy_example2(my_namespace::my_alph & val) : ptr{&val} {}
+
+    constexpr alphabet_proxy_example2 & operator=(alphabet_proxy_example2 const & rhs)
+    {
+        return assign_rank(rhs.to_rank());
+    }
+
+    constexpr alphabet_proxy_example2 const & operator=(alphabet_proxy_example2 const & rhs) const
+    {
+        return assign_rank(rhs.to_rank());
+    }
+
+    constexpr size_t to_rank() const noexcept { return ptr->rank; }
+
+    constexpr alphabet_proxy_example2 & assign_rank(size_t const r) noexcept
+    {
+        ptr->rank = r;
+        return *this;
+    }
+
+    constexpr alphabet_proxy_example2 const & assign_rank(size_t const r) const noexcept
+    {
+        ptr->rank = r;
+        return *this;
+    }
 };
 
-INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy2, alphabet, alphabet_proxy_example2, );
-INSTANTIATE_TYPED_TEST_SUITE_P(alphabet_proxy2, alphabet_constexpr, alphabet_proxy_example2, );
+template <>
+struct proxy_fixture<alphabet_proxy_example2> : public ::testing::Test
+{
+    my_namespace::my_alph def{};
+    my_namespace::my_alph a0{0};
+    my_namespace::my_alph a1{1};
+
+    alphabet_proxy_example2 default_init{def};
+    alphabet_proxy_example2 t0{a0};
+    alphabet_proxy_example2 t1{a1};
+};
+
+INSTANTIATE_TYPED_TEST_SUITE_P(proxy2_test, proxy_fixture, ::testing::Types<alphabet_proxy_example2>, );

--- a/test/unit/alphabet/quality/qualified_test.cpp
+++ b/test/unit/alphabet/quality/qualified_test.cpp
@@ -18,6 +18,7 @@
 #include <bio/alphabet/quality/qualified.hpp>
 
 #include "../alphabet_constexpr_test_template.hpp"
+#include "../alphabet_proxy_test_template.hpp"
 #include "../alphabet_test_template.hpp"
 #include "../composite/alphabet_tuple_base_test_template.hpp"
 #include "../semi_alphabet_constexpr_test_template.hpp"
@@ -74,3 +75,23 @@ INSTANTIATE_TYPED_TEST_SUITE_P(qualified, semi_alphabet_test, qualified_types, )
 INSTANTIATE_TYPED_TEST_SUITE_P(qualified, alphabet_constexpr, qualified_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(qualified, semi_alphabet_constexpr, qualified_types, );
 INSTANTIATE_TYPED_TEST_SUITE_P(qualified, alphabet_tuple_base_test, qualified_types, );
+
+using bio::alphabet::operator""_dna4;
+using bio::alphabet::operator""_phred42;
+
+using tup   = bio::alphabet::qualified<bio::alphabet::dna4, bio::alphabet::phred42>;
+using ref_t = decltype(get<0>(std::declval<tup &>()));
+
+template <>
+struct proxy_fixture<ref_t> : public ::testing::Test
+{
+    tup data_def{'A'_dna4, '!'_phred42};
+    tup data_t0{'A'_dna4, '!'_phred42};
+    tup data_t1{'C'_dna4, '!'_phred42};
+
+    ref_t default_init{get<0>(data_def)};
+    ref_t t0{get<0>(data_t0)};
+    ref_t t1{get<0>(data_t1)};
+};
+
+INSTANTIATE_TYPED_TEST_SUITE_P(proxy_test, proxy_fixture, ::testing::Types<ref_t>, );

--- a/test/unit/ranges/container/bitcompressed_vector_test.cpp
+++ b/test/unit/ranges/container/bitcompressed_vector_test.cpp
@@ -54,3 +54,28 @@ TEST(bitcompressed_vector_test, gap_compatibility)
     bio::ranges::bitcompressed_vector<bio::alphabet::gap> v;
     EXPECT_TRUE(bio::alphabet::writable_alphabet<decltype(v[0])>);
 }
+
+TEST(bitcompressed_vector_test, const_assignability)
+{
+    bio::ranges::bitcompressed_vector<bio::alphabet::dna4> v{"ACGT"_dna4};
+    auto const                                             ref = *v.begin();
+    ref                                                        = 'T'_dna4;
+    EXPECT_RANGE_EQ(v, "TCGT"_dna4);
+}
+
+#include "../../alphabet/alphabet_proxy_test_template.hpp"
+
+using bio::alphabet::operator""_dna4;
+using ref_t = std::ranges::range_reference_t<bio::ranges::bitcompressed_vector<bio::alphabet::dna4>>;
+
+template <>
+struct proxy_fixture<ref_t> : public ::testing::Test
+{
+    bio::ranges::bitcompressed_vector<bio::alphabet::dna4> data{"AAC"_dna4};
+
+    ref_t default_init{data[0]};
+    ref_t t0{data[1]};
+    ref_t t1{data[2]};
+};
+
+INSTANTIATE_TYPED_TEST_SUITE_P(proxy_test, proxy_fixture, ::testing::Types<ref_t>, );

--- a/test/unit/ranges/container/container_test_template.hpp
+++ b/test/unit/ranges/container/container_test_template.hpp
@@ -26,8 +26,7 @@ TYPED_TEST_P(container_over_dna4_test, concepts)
 {
     EXPECT_TRUE(bio::ranges::detail::reservible_container<TypeParam>);
     EXPECT_TRUE(std::ranges::forward_range<TypeParam>);
-    //TODO
-    //EXPECT_TRUE((std::ranges::output_range<TypeParam, bio::alphabet::dna4>));
+    EXPECT_TRUE((std::ranges::output_range<TypeParam, bio::alphabet::dna4>));
 }
 
 TYPED_TEST_P(container_over_dna4_test, construction)
@@ -172,11 +171,6 @@ TYPED_TEST_P(container_over_dna4_test, element_access)
 
     t1.begin()[1] = t2.begin()[4];
     EXPECT_RANGE_EQ(t1, "ATAGG"_dna4);
-
-    // TODO: this needs to work for proper output range support
-    //     auto const ref = *t1.begin();
-    //     ref = 'T'_dna4;
-    //     EXPECT_RANGE_EQ(t1, "TTAGG"_dna4);
 }
 
 TYPED_TEST_P(container_over_dna4_test, capacity)


### PR DESCRIPTION
This fixes some fundamental flaws in the previous proxy design. Among other things, `std::ranges::output_range<bitcompressed_vector<dna4>, dna4>` was previously always false.

Proxies now have correct "assign-through" behaviour, const-assignability, and tests that verify this.